### PR TITLE
Reset Tremor seek cache in ov_clear

### DIFF
--- a/lib/rbcodec/codecs/libtremor/vorbisfile.c
+++ b/lib/rbcodec/codecs/libtremor/vorbisfile.c
@@ -1005,6 +1005,9 @@ int ov_clear(OggVorbis_File *vf){
     if(vf->serialnos)_ogg_free(vf->serialnos);
     if(vf->offsets)_ogg_free(vf->offsets);
     ogg_sync_clear(&vf->oy);
+    /* reset seek cache so leftover data doesn't affect the next file */
+    seekcache.abs_off = -1;
+    seekcache.used    = 0;
     if(vf->datasource && vf->callbacks.close_func)
       (vf->callbacks.close_func)(vf->datasource);
     memset(vf,0,sizeof(*vf));


### PR DESCRIPTION
## Summary
- clear `seekcache` when closing a stream

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687cbe8ff3908321a423a80ff43ec063