### PR TITLE
Fix back button directory after bookmark resume

### DIFF
--- a/apps/root_menu.c
+++ b/apps/root_menu.c
@@ -129,15 +129,17 @@ static int browser(void* param)
     {
         case GO_TO_FILEBROWSER:
             filter = global_settings.dirfilter;
+            if (!strcmp(last_folder, "/") && current_track_path[0])
+                strlcpy(last_folder, current_track_path, sizeof(last_folder));
             if (global_settings.browse_current &&
                     last_screen == GO_TO_WPS &&
                     current_track_path[0])
             {
-                strcpy(folder, current_track_path);
+                strlcpy(folder, current_track_path, sizeof(folder));
             }
             else if (!strcmp(last_folder, "/"))
             {
-                strcpy(folder, global_settings.start_directory);
+                strlcpy(folder, global_settings.start_directory, sizeof(folder));
             }
             else
             {


### PR DESCRIPTION
## Summary
- ensure file browser opens the playing track's directory after resuming from bookmark

## Testing
- `git commit`

------
https://chatgpt.com/codex/tasks/task_e_687cd6e5ee6c8321b734313cde9434f1